### PR TITLE
Added support for xdg specification config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ OPTIONS:
 
 Gotify-CLI will search the following paths for a config file:
 * `/etc/gotify/cli.json`
+* `$XDG_CONFIG_HOME/gotify/cli.json`
 * `~/.gotify/cli.json`
 * `./cli.json`
 

--- a/config/locations.go
+++ b/config/locations.go
@@ -4,10 +4,17 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+
+	"github.com/adrg/xdg"
 )
 
 func GetLocations() (res []string) {
 	res = append(res, "./cli.json")
+
+	xdgPath, err := xdg.ConfigFile(filepath.Join("gotify", "cli.json"))
+	if err == nil {
+		res = append(res, xdgPath)
+	}
 
 	if usr, err := user.Current(); err == nil {
 		res = append(res, filepath.Join(usr.HomeDir, ".gotify", "cli.json"))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/gotify/cli/v2
 
 require (
+	github.com/adrg/xdg v0.2.1
 	github.com/go-openapi/analysis v0.19.0 // indirect
 	github.com/go-openapi/errors v0.19.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.0 // indirect
@@ -19,3 +20,5 @@ require (
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
 	gopkg.in/urfave/cli.v1 v1.20.0
 )
+
+go 1.14

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tN
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/adrg/xdg v0.2.1 h1:VSVdnH7cQ7V+B33qSJHTCRlNgra1607Q8PzEmnvb2Ic=
+github.com/adrg/xdg v0.2.1/go.mod h1:ZuOshBmzV4Ta+s23hdfFZnBsdzmoR3US0d7ErpqSbTQ=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzsP1G42dRafH3vf+al2vQIJU0YHX+1Tw87oco=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
- old config paths still supported
- introduced dependency on "github.com/adrg/xdg" to more easily handle cross-platform spec

Fixes #31 