### PR TITLE
Add environment variable and docs to allow skip TLS verification - Fix #27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.12.3"
+- "1.14.3"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ Gotify-CLI will search the following paths for a config file:
 }
 ```
 
+## Configuration option
+
+If needed, you can disable SSL handcheck validation using an environment variable:
+```
+export GOTIFY_SKIP_VERIFY_TLS=True
+```
+
+
 ### Dockerfile
 The Dockerfile contains the steps necessary to build a new version of the CLI and then run it in 
 a minimal Alpine container.

--- a/command/initialize.go
+++ b/command/initialize.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bufio"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -34,7 +33,7 @@ func Init() cli.Command {
 func doInit(ctx *cli.Context) {
 	serverURL := inputServerURL()
 	hr()
-	token := inputToken(gotify.NewClient(serverURL, &http.Client{}))
+	token := inputToken(gotify.NewClient(serverURL, utils.CreateHTTPClient()))
 	hr()
 
 	conf := &config.Config{
@@ -224,7 +223,7 @@ func inputServerURL() *url.URL {
 		}
 
 		version, err := utils.SpinLoader("Connecting", func(success chan interface{}, failure chan error) {
-			client := gotify.NewClient(parsedURL, &http.Client{})
+			client := gotify.NewClient(parsedURL, utils.CreateHTTPClient())
 
 			ver, e := client.Version.GetVersion(nil)
 			if e == nil {

--- a/command/push.go
+++ b/command/push.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -89,7 +88,8 @@ func doPush(ctx *cli.Context) {
 }
 
 func pushMessage(parsedURL *url.URL, token string, msg models.MessageExternal, quiet bool) {
-	client := gotify.NewClient(parsedURL, &http.Client{})
+
+	client := gotify.NewClient(parsedURL, utils.CreateHTTPClient())
 
 	params := message.NewCreateMessageParams()
 	params.Body = &msg

--- a/utils/createhttpclient.go
+++ b/utils/createhttpclient.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"crypto/tls"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func CreateHTTPClient() *http.Client {
+	skipVerify := strings.ToLower(os.Getenv("GOTIFY_SKIP_VERIFY_TLS")) == "true"
+	customTransport := http.DefaultTransport.(*http.Transport).Clone()
+	customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: skipVerify}
+	return &http.Client{Transport: customTransport}
+}


### PR DESCRIPTION
Adding a rather explicit option to ignore SSL validation, this is required in case of self signed x509s.