### PR TITLE
ci: only release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,16 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Go Check"]
-    types:
-      - completed
-    branches:
-      - master
+  push:
+    tags:
+      - v*
 
 jobs:
   release:
-    
+
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Release failed because there was no tag there: https://github.com/gotify/cli/actions/runs/10202937016

@eternal-flame-AD 