### PR TITLE
feat: Automatically split STDIN on null characters on push

### DIFF
--- a/command/initialize.go
+++ b/command/initialize.go
@@ -71,7 +71,7 @@ func inputConfigLocation() string {
 	for {
 		fmt.Println("Where to put the config file?")
 		for i, location := range locations {
-			fmt.Println(fmt.Sprintf("%d. %s", i+1, location))
+			fmt.Printf("%d. %s\n", i+1, location)
 		}
 		value := inputString("Enter a number: ")
 		hr()
@@ -215,9 +215,9 @@ func inputDefaultPriority() int {
 			erred("Priority needs to be a number between 0 and 10.")
 			continue
 		} else {
+			hr()
 			return defaultPriority
 		}
-		hr()
 	}
 }
 
@@ -251,7 +251,7 @@ func inputServerURL() *url.URL {
 		})
 		if err == nil {
 			info := version.(models.VersionInfo)
-			fmt.Println(fmt.Sprintf("Gotify v%s@%s", info.Version, info.BuildDate))
+			fmt.Printf("Gotify v%s@%s\n", info.Version, info.BuildDate)
 			return parsedURL
 		}
 		hr()

--- a/command/read.go
+++ b/command/read.go
@@ -1,0 +1,61 @@
+package command
+
+import (
+	"io"
+	"strings"
+
+	"github.com/gotify/cli/v2/utils"
+)
+
+func readMessage(args []string, r io.Reader, output chan<- string, split *rune) {
+	msgArgs := strings.Join(args, " ")
+
+	if msgArgs != "" {
+		if utils.ProbeStdin(r) {
+			utils.Exit1With("message is set via arguments and stdin, use only one of them")
+		}
+
+		output <- msgArgs
+		close(output)
+		return
+	}
+
+	var buf strings.Builder
+	for {
+		var tmp [256]byte
+		n, err := r.Read(tmp[:])
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			utils.Exit1With(err)
+		}
+		tmpStr := string(tmp[:n])
+		if split != nil {
+			// split the message on the null character
+			parts := strings.Split(tmpStr, string(*split))
+			if len(parts) == 1 {
+				buf.WriteString(parts[0])
+				continue
+			}
+
+			previous := buf.String()
+			// fuse previous with parts[0], send parts[1] .. parts[n-2] and set parts[n-1] as new previous
+			firstMsg := previous + parts[0]
+			output <- firstMsg
+			for _, part := range parts[1 : len(parts)-1] {
+				output <- part
+			}
+			buf.Reset()
+			buf.WriteString(parts[len(parts)-1])
+		} else {
+			buf.WriteString(tmpStr)
+		}
+	}
+
+	if buf.Len() > 0 {
+		output <- buf.String()
+	}
+
+	close(output)
+}

--- a/command/read_test.go
+++ b/command/read_test.go
@@ -1,0 +1,55 @@
+package command
+
+import (
+	"strings"
+	"testing"
+)
+
+// Polyfill for slices.Equal for Go 1.20
+func slicesEqual[T comparable](a, b []T) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func readChanAll[T any](c chan T) []T {
+	var res []T
+	for s := range c {
+		res = append(res, s)
+	}
+	return res
+}
+
+func TestReadMessage(t *testing.T) {
+	var split rune = '\x00'
+
+	// Test case 1: message set via arguments
+	output := make(chan string)
+	go readMessage([]string{"Hello", "World"}, nil, output, nil)
+
+	if res := readChanAll(output); !(slicesEqual(res, []string{"Hello World"})) {
+		t.Errorf("Expected %v, but got %v", []string{"Hello World"}, res)
+	}
+
+	// Test case 2: message set via arguments should not split on 'split' character
+	output = make(chan string)
+	go readMessage([]string{"Hello\x00World"}, nil, output, &split)
+
+	if res := readChanAll(output); !(slicesEqual(res, []string{"Hello\x00World"})) {
+		t.Errorf("Expected %v, but got %v", []string{"Hello\x00World"}, res)
+	}
+
+	// Test case 3: message set via stdin
+	output = make(chan string)
+	go readMessage([]string{}, strings.NewReader("Hello\x00World"), output, &split)
+
+	if res := readChanAll(output); !(slicesEqual(res, []string{"Hello", "World"})) {
+		t.Errorf("Expected %v, but got %v", []string{"Hello", "World"}, res)
+	}
+}

--- a/command/watch.go
+++ b/command/watch.go
@@ -120,18 +120,18 @@ func doWatch(ctx *cli.Context) {
 			case "long":
 				fmt.Fprintf(msgData, "command output for \"%s\" changed:\n\n", cmdStringNotation)
 				fmt.Fprintln(msgData, "== BEGIN OLD OUTPUT ==")
-				fmt.Fprint(msgData, lastOutput)
+				fmt.Fprintln(msgData, lastOutput)
 				fmt.Fprintln(msgData, "== END OLD OUTPUT ==")
 				fmt.Fprintln(msgData, "== BEGIN NEW OUTPUT ==")
-				fmt.Fprint(msgData, output)
+				fmt.Fprintln(msgData, output)
 				fmt.Fprintln(msgData, "== END NEW OUTPUT ==")
 			case "default":
 				fmt.Fprintf(msgData, "command output for \"%s\" changed:\n\n", cmdStringNotation)
 				fmt.Fprintln(msgData, "== BEGIN NEW OUTPUT ==")
-				fmt.Fprint(msgData, output)
+				fmt.Fprintln(msgData, output)
 				fmt.Fprintln(msgData, "== END NEW OUTPUT ==")
 			case "short":
-				fmt.Fprintf(msgData, output)
+				fmt.Fprintln(msgData, output)
 			}
 
 			msgString := msgData.String()

--- a/utils/readfromstdin.go
+++ b/utils/readfromstdin.go
@@ -1,22 +1,23 @@
 package utils
 
 import (
+	"io"
 	"os"
-	"io/ioutil"
 )
 
-func ReadFrom(file *os.File) string {
-	fi, err := os.Stdin.Stat()
-	if err != nil {
-		return ""
+func ProbeStdin(file io.Reader) bool {
+	if file == nil {
+		return false
 	}
-	if fi.Mode()&os.ModeNamedPipe == 0 && !fi.Mode().IsRegular() {
-		return ""
+	if file, ok := file.(*os.File); ok {
+		fi, err := file.Stat()
+		if err != nil {
+			return false
+		}
+		if fi.Mode()&os.ModeNamedPipe == 0 && !fi.Mode().IsRegular() {
+			return false
+		}
 	}
 
-	bytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return ""
-	}
-	return string(bytes)
+	return true
 }


### PR DESCRIPTION
This fixes #69.

Added a feature to split on null characters when reading from stdin. This way users can have one long-running `gotify push` and simply piping things to it.